### PR TITLE
Use labels to manage cms workflow

### DIFF
--- a/.github/pr-branch-labeler.yml
+++ b/.github/pr-branch-labeler.yml
@@ -1,0 +1,3 @@
+'review needed':
+  head: "cms/*"
+

--- a/.github/wip.yml
+++ b/.github/wip.yml
@@ -1,0 +1,9 @@
+locations:
+  - title
+  - label_name
+terms:
+  - wip
+  - 'work in progress'
+  - 🚧
+  - 'review needed'
+

--- a/.github/workflows/pr-branch-labeler.yml
+++ b/.github/workflows/pr-branch-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Branch Labeler
+
+on: pull_request
+
+jobs:
+  label_prs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label PRs
+      if: github.event.action == 'opened' # Only run the action when the PR was first opened
+      uses: ffittschen/pr-branch-labeler@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This configures the pr-branch-labeler action to label PR's generated by the Netlify CMS in a way that will trigger the WIP app. The purpose of this is to ensure a GH review of the code is done prior to merging of new content.