### PR TITLE
Add calendar page

### DIFF
--- a/content/committee/vc-program/calendar.md
+++ b/content/committee/vc-program/calendar.md
@@ -1,0 +1,10 @@
+---
+title: 'District Calendar'
+date: '2021-08-28T10:00:00-0400'
+mermaid: false
+aliases:
+  - /calendar.html
+  - /calendar/
+---
+
+{{<district-calendar>}}

--- a/layouts/shortcodes/district-calendar.html
+++ b/layouts/shortcodes/district-calendar.html
@@ -1,0 +1,2 @@
+<iframe src="https://calendar.google.com/calendar/embed?src=ad4mt9gm8q7138kc0gc9sj8sfs%40group.calendar.google.com&ctz=America%2FNew_York"
+  style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
This includes an embeddd Google Calendar. The calendar is available at the following URLs:

- /committee/vc-program/calendar/
- /calendar/
- /calendar.html

I suggest advertising it as https://www.indianspringsbsa.org/calendar once this is published