### PR TITLE
Adding name to select on nomination form

### DIFF
--- a/layouts/shortcodes/nomination-form.html
+++ b/layouts/shortcodes/nomination-form.html
@@ -28,7 +28,7 @@
     <hr>
     <h3>Award information</h3>
     <fieldset>
-      <select id="award" tabindex="7">
+      <select id="award" name="award_selected" tabindex="7">
         <option value="default" selected>Which award are you nominating someone for?</option>
         <option value="Russell Turner Lifetime Service Award">Russell Turner Lifetime Service Award</option>
         <option value="Scoutmaster of the Year">Scoutmaster of the Year</option>


### PR DESCRIPTION
This is a fix for an epic fail in which the award people were being nominated for was not included in the form submission.